### PR TITLE
Enable wrapper chars

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,12 @@ module.exports = () => {
                         file = segs.join('/');
                     }
 
-                    let value = `${file} (${path.node.loc.start.line}:${path.node.loc.start.column})`
+                    let wrapperChars = ["", ""]
+                    if(typeof opts.wrappingChars === "string" && opts.wrapperChars.length === 2) {
+                        wrapperChars = opts.wrapPathFunction;
+                    }
+
+                    let value = wrapPathFunction(`${wrapperChars[0]}${file} (${path.node.loc.start.line}:${path.node.loc.start.column})${wrapperChars[1]}`)
 
                     if(path.node.arguments[0].value !== value) {
                         path.node.arguments.unshift({


### PR DESCRIPTION
Sometimes I want to wrap file names etc in a wrapper chars

for example

`[fileName...]`

In this PR I enable it but by default its empty strings.

It would be used as:


```
wrapperChars: "[]"
```

or whatever combination of wrapper chars you want.

We can make it more general with a function but not sure if that's required at this point.