### PR TITLE
Enable wrapper chars

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,12 @@ module.exports = () => {
                         file = segs.join('/');
                     }
 
-                    let value = `${file} (${path.node.loc.start.line}:${path.node.loc.start.column})`
+                    let wrapperChars = ["", ""]
+                    if(typeof opts.wrapperChars === "string" && opts.wrapperChars.length === 2) {
+                        wrapperChars = opts.wrapperChars;
+                    }
+
+                    let value = `${wrapperChars[0]}${file} (${path.node.loc.start.line}:${path.node.loc.start.column})${wrapperChars[1]}`
 
                     if(path.node.arguments[0].value !== value) {
                         path.node.arguments.unshift({

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = () => {
                         file = segs.join('/');
                     }
 
-                    let wrapperChars = ["", ""]
+                    let wrapperChars = ['', '']
                     if(typeof opts.wrapperChars === "string" && opts.wrapperChars.length === 2) {
                         wrapperChars = opts.wrapperChars;
                     }


### PR DESCRIPTION
Sometimes I want to wrap the file names and other specifiers inside wrapper chars

for example I would use

```
wrapperChars: "[]"
```

to wrap it in [] paranthesis.

So that I have

```
[file specifier] log
```

We can make it more general so it takes a function, but not sure that is required at this point.